### PR TITLE
Chore: Separating publishing nuget package into it's own workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,52 @@
+name: publish nuget package
+
+on:
+  workflow_call:
+    inputs:
+      package-version:
+        type: string
+        required: true
+        description: Version of the package to publish (e.g., 1.0.0)
+      dotnet-version:
+        type: string
+        required: true
+        description: Version of .NET to use (e.g., 8.0.x)
+      project-name:
+        type: string
+        required: true
+        description: Path to the csproj file
+      release-notes-url:
+        type: string
+        required: true
+        description: URL for release notes
+
+permissions:
+  contents: write
+  packages: write
+  
+jobs:
+  ci_validations:
+    name: Restore, Build, and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            ${{ inputs.dotnet-version }}
+          source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Restore Dependencies
+        run: dotnet restore src/${{ inputs.project-name }}/${{ inputs.project-name }}.csproj
+      - name: Build
+        run: dotnet build --configuration Release --no-restore src/${{ inputs.project-name }}/${{ inputs.project-name }}.csproj
+      - name: Create Package
+        run: dotnet pack --configuration Release --no-build -p:ContinuousIntegrationBuild=true -p:PackageVersion=${{ inputs.package-version }} -p:PackageReleaseNotes="See ${{ inputs.release-notes-url }}" src/${{ inputs.project-name }}/${{ inputs.project-name }}.csproj
+      - name: Push to GitHub Packages
+        run: dotnet nuget push "src/${{ inputs.project-name }}/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --skip-duplicate
+    
+    
+  

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -64,28 +64,11 @@ jobs:
     
   publishpackage:
     name: Publish Package
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    needs:
+    needs: 
       - release
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: |
-            8.0.x
-          source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Restore Dependencies
-        run: dotnet restore src/ShotCaller.Azure.ServiceBus.Messaging/ShotCaller.Azure.ServiceBus.Messaging.csproj
-      - name: Build
-        run: dotnet build --configuration Release --no-restore src/ShotCaller.Azure.ServiceBus.Messaging/ShotCaller.Azure.ServiceBus.Messaging.csproj
-      - name: Create Package
-        run: dotnet pack --configuration Release --no-build -p:ContinuousIntegrationBuild=true -p:PackageVersion=${{ needs.release.outputs.VersionNumber }} -p:PackageReleaseNotes="See https://github.com/Cheranga/shotcaller/releases/tag/${{ needs.release.outputs.VersionNumber }}" src/ShotCaller.Azure.ServiceBus.Messaging/ShotCaller.Azure.ServiceBus.Messaging.csproj
-      - name: Push to GitHub Packages
-        run: dotnet nuget push "src/ShotCaller.Azure.ServiceBus.Messaging/bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --skip-duplicate
+    uses: ./.github/workflows/publish-package.yml
+    with:
+      dotnet-version: 8.0.x
+      package-version: ${{ needs.release.outputs.VersionNumber }}
+      project-name: ShotCaller.Azure.ServiceBus.Messaging
+      release-notes-url: https://github.com/Cheranga/shotcaller/releases/tag/${{ needs.release.outputs.VersionNumber }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a reusable workflow for publishing NuGet packages, allowing other workflows to call it with specific parameters.
  * Streamlined the release process by updating the release workflow to use the new reusable workflow, reducing duplication and simplifying maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->